### PR TITLE
Properly get rid of ansible warning regarding curl

### DIFF
--- a/tasks/latest.yml
+++ b/tasks/latest.yml
@@ -1,12 +1,17 @@
 ---
 - name: Latest - Get the latest version.
-  shell: "curl -sLI -o /dev/null -w %{url_effective} https://github.com/glowroot/glowroot/releases/latest |awk -F'/v' '{print $NF}'"
+  uri:
+    url: https://api.github.com/repos/glowroot/glowroot/releases/latest
+    method: GET
+    headers:
+      Accept: application/vnd.github.v3+json
+    body_format: json
   register: get_latest_version
   changed_when: false
 
 - name: Latest - Set glowroot_version with the latest version.
   set_fact:
-    glowroot_version: "{{ get_latest_version.stdout }}"
+    glowroot_version: "{{ get_latest_version.json.tag_name[1:] }}"
 
 - name: Latest - Get the actual version.
   shell: "java -jar {{ glowroot_home_dir}}/glowroot.jar version |awk -F',' '{print $1}'"


### PR DESCRIPTION
This patch replace the use of curl with the command module by the uri
module, as suggested by Ansible.